### PR TITLE
switch box64 rpi4 package to box64-rpi4arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ These debs have been compiled using various target CPUs and systems. You can see
 ## Package List
 Package Name | Notes | Install Command |
 ------------ | ------------- | ------------- |
-| box64 | Box64 built for RPI4ARM64 target. | `sudo apt install box64` |
+| box64-rpi4arm64 | Box64 built for RPI4ARM64 target. | `sudo apt install box64-rpi4arm64` |
 | box64-rpi3arm64 | Box64 built for RPI3ARM64 target. | `sudo apt install box64-rpi3arm64` |
 | box64-generic-arm | Box64 built for generic ARM systems. | `sudo apt install box64-generic-arm` |
 | box64-tegrax1 | Box64 built for Tegra X1 systems. | `sudo apt install box64-tegrax1` |

--- a/create-deb.sh
+++ b/create-deb.sh
@@ -78,12 +78,7 @@ for target in ${targets[@]}; do
   echo 'Restarting systemd-binfmt...'
   systemctl restart systemd-binfmt || true" > postinstall-pak || error "Failed to create postinstall-pak!"
 
-  # use the pi4 target as the default box64 package
-  if [[ $target == "RPI4ARM64" ]]; then
-    sudo checkinstall -y -D --pkgversion="$DEBVER" --arch="arm64" --provides="box64" --conflicts="qemu-user-static" --pkgname="box64" --install="no" make install || error "Checkinstall failed to create a deb package."
-  else
-    sudo checkinstall -y -D --pkgversion="$DEBVER" --arch="arm64" --provides="box64" --conflicts="qemu-user-static" --pkgname="box64-$target" --install="no" make install || error "Checkinstall failed to create a deb package."
-  fi
+  sudo checkinstall -y -D --pkgversion="$DEBVER" --arch="arm64" --provides="box64" --conflicts="qemu-user-static" --pkgname="box64-$target" --install="no" make install || error "Checkinstall failed to create a deb package."
 
   cd $DIRECTORY
   mv box64/build/*.deb ./debian/ || error "Failed to move deb to debian folder."


### PR DESCRIPTION
all packages provide box64 so any other package can still depend on box64. previously the user could not guarantee the installation of the rpi4 box64 package, installing box64 would result in a random selection of any of the packages that provide it. now the user or script can select the box64-rpi4arm64 target explicitly